### PR TITLE
Docs: Fixed type inference example in Numerics section

### DIFF
--- a/src/doc/book/primitive-types.md
+++ b/src/doc/book/primitive-types.md
@@ -51,7 +51,7 @@ These types consist of two parts: the category, and the size. For example,
 `u16` is an unsigned type with sixteen bits of size. More bits lets you have
 bigger numbers.
 
-If a number literal has nothing to cause its type to be inferred, it defaults:
+If the type is not specified, the compiler infers the type based on the assigned value:
 
 ```rust
 let x = 42; // x has type i32


### PR DESCRIPTION
This is a fix to a passage in Numeric types. There are two examples of type inference here (e.g. let x = 42; // x has type i32). However, the examples are introduced with the following statement: "If a number literal has nothing to cause its type to be inferred, it defaults:" These are actual examples of type inference, so it doesn't make sense to say that there is "nothing to cause its type to be inferred" _only to then demonstrate its type being inferred_... Changed it to: "If the type is not specified, the compiler infers the type based on the assigned value:" (I also wanted to be explicit about who/what is making the inference – the compiler).
